### PR TITLE
Retrieve JWT_SECRET_KEY from enviroment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ foo@bar:~$ docker build . -f Dockerfile.local -t arcticfox
 foo@bar:~$ docker run --name arcticfox -p 5000:5000 --env JWT_SECRET_KEY=$(openssl rand -base64 21) arcticfox
 ```
 
-#### To get the JWT_SECRET_KEY:
+#### To get the JWT_SECRET_KEY
   ```console
   foo@bar:~$ docker exec -it arcticfox bash -c 'echo $JWT_SECRET_KEY'
   ```

--- a/README.md
+++ b/README.md
@@ -8,5 +8,10 @@ Application created with the intention to be secured on vulnerabilities.
 ### Run the application on a docker container
 ```console
 foo@bar:~$ docker build . -f Dockerfile.local -t arcticfox
-foo@bar:~$ docker run -p 5000:5000 arcticfox
+foo@bar:~$ docker run --name arcticfox -p 5000:5000 --env JWT_SECRET_KEY=$(openssl rand -base64 21) arcticfox
 ```
+
+#### To get the JWT_SECRET_KEY:
+  ```console
+  foo@bar:~$ docker exec -it arcticfox bash -c 'echo $JWT_SECRET_KEY'
+  ```

--- a/backend/app.py
+++ b/backend/app.py
@@ -14,8 +14,9 @@ app = Flask(__name__, static_folder="static/web-build", static_url_path="/")
 jwt = JWTManager(app)
 CORS(app)
 
+JWT_SECRET_KEY = os.environ["JWT_SECRET_KEY"]
 app.config["CORS_HEADERS"] = "Content-Type"
-app.config["JWT_SECRET_KEY"] = os.environ["JWT_SECRET_KEY"]
+app.config["JWT_SECRET_KEY"] = JWT_SECRET_KEY
 app.config["JWT_TOKEN_LOCATION"] = ["headers", "query_string"]
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///database.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False

--- a/backend/app.py
+++ b/backend/app.py
@@ -10,18 +10,19 @@ from flask_cors import CORS
 from flask_jwt_extended import JWTManager, create_access_token, get_jwt_identity, jwt_required
 from werkzeug.utils import secure_filename
 
-ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
 app = Flask(__name__, static_folder="static/web-build", static_url_path="/")
 jwt = JWTManager(app)
 CORS(app)
+
 app.config["CORS_HEADERS"] = "Content-Type"
-app.config["JWT_SECRET_KEY"] = "random key secret must change"
+app.config["JWT_SECRET_KEY"] = os.environ["JWT_SECRET_KEY"]
 app.config["JWT_TOKEN_LOCATION"] = ["headers", "query_string"]
 app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///database.db"
 app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 app.config["UPLOAD_FOLDER"] = str(Path(__file__).resolve().parent) + "/static/uploads/"
 app.config["TEMPLATES_AUTO_RELOAD"] = True
 app.config["JWT_ACCESS_TOKEN_EXPIRES"] = timedelta(days=1)
+
 database.db.init_app(app)
 
 # Creates all database tables if they do not exist
@@ -42,6 +43,7 @@ with app.app_context():
 
 # ==========================HELPER-FUNCTIONS=======================
 def allowed_file(filename):
+    ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
     return "." in filename and \
            filename.rsplit(".", 1)[1].lower() in ALLOWED_EXTENSIONS
 
@@ -398,7 +400,7 @@ def admin_register():
             password = request.form["password"]
             email = request.form["email"]
             secret_password = request.form["secret_password"]
-            if secret_password == "TOPSECRETPASSWORD":
+            if secret_password == JWT_SECRET_KEY:
                 admin_id = database.add_admin(username, password, email)
                 if isinstance(admin_id, int):
                     access_token = create_access_token(identity=admin_id)


### PR DESCRIPTION
Now JWT_SECRET_KEY is copied from the enviroment variables. This adds a layer of security as there are not any hardcoded passwords. Admin registration now uses the same value. 
In case there is not a enviroment variable named 'JWT_SECRET_KEY' the app just crashes and exits. There is not any proper message except for `KeyError: 'JWT_SECRET_KEY'` for the avoidance of non-mandatory code.
# Fixes #3 Fixes #4 
There have been added proper guides for the docker deploy.